### PR TITLE
GitHubのアクセストークンをクエリパラメータで渡すことが非推奨になったため、Authorizationヘッダで渡すように変更

### DIFF
--- a/zespa/github_requester.py
+++ b/zespa/github_requester.py
@@ -26,8 +26,10 @@ class GitHubRequester():
         return issues
 
     def _fetch_issues(self, start_date, end_date, page=1):
-        resp = requests.get(f'{GITHUB_SEARCH_API}?access_token={self.token}&per_page={PER_PAGE}&page={page}' +
-                            f'&q=is:issue+is:closed+closed:{start_date}..{end_date}+repo:{self.repo_name}')
+        headers = { 'Authorization': f'token {self.token}' }
+        url = f'{GITHUB_SEARCH_API}?per_page={PER_PAGE}&page={page}' \
+              f'&q=is:issue+is:closed+closed:{start_date}..{end_date}+repo:{self.repo_name}'
+        resp = requests.get(url=url, headers=headers)
         issues = json.loads(resp.content.decode('utf-8'))
         try:
             return issues['items'] or []


### PR DESCRIPTION
こんにちは。毎月このツールにお世話になっています ✋ ✋ 

GitHubのアクセストークンをクエリパラメータで渡すことが非推奨になったようなので、代わりにAuthorizationヘッダで渡すように変更する修正を加えました。
参考 - https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param

ツールを利用したときにGitHubから「非推奨になりもうすぐ使えなくなるので使っている人にリマインダのメールを送っています」というメールも飛ぶようになっているようなので、取り込んでPyPIにもpublish頂けると嬉しいです。

よろしくお願いします！