### PR TITLE
クエリで取得できるIssueの件数がPER_PAGEで割り切れるときに無限ループになる問題に対処しました

### DIFF
--- a/zespa/github_requester.py
+++ b/zespa/github_requester.py
@@ -19,8 +19,9 @@ class GitHubRequester():
         page = 1
         issues = []
         while True:
-            issues += self._fetch_issues(start_date, end_date, page)
-            if issues == [] or len(issues) % PER_PAGE != 0:
+            fetched_issues = self._fetch_issues(start_date, end_date, page)
+            issues += fetched_issues
+            if fetched_issues == [] or len(issues) % PER_PAGE != 0:
                 break
             page += 1
         return issues


### PR DESCRIPTION
こんにちは！いつも利用させていただいています！

非常にまれなケースを踏んでしまったので、その対策をしてみました。
取り込んでいただけると嬉しいです。

# 起きていたこと

ページングされたGitHub Issueをすべて取得する処理において、 **条件にマッチするIssueの数が1ページあたりの表示数で割り切れる場合** にページ取得処理が終了せず、永遠に次のページを探すリクエストを発行する現象を見つけました。

# 修正概要

ページ毎のIssue取得ループの終了条件を以下のように変更しました

- 旧: 処理中取得した全てのIssueの件数が0件、または処理中取得したIssueの件数が1ページあたりの表示件数で割り切れない
- 新: ページを指定して取得したIssueの件数が0件、または処理中取得したIssueの件数が1ページあたりの表示件数で割り切れない

# 気になっているところ

ラインコメントを記載しました！


よろしくお願いします！
